### PR TITLE
Release/v1.1.1

### DIFF
--- a/.changeset/disable-db-push.md
+++ b/.changeset/disable-db-push.md
@@ -1,0 +1,5 @@
+---
+"training-app": patch
+---
+
+Disable Postgres schema auto-push (`push: false`). Schema changes now go exclusively through migrations (`payload migrate:create` + `payload migrate`), so running `yarn dev` can no longer sync schema directly into a remote/production database. After this change a fresh database must be migrated before the app can run.

--- a/.changeset/disable-db-push.md
+++ b/.changeset/disable-db-push.md
@@ -1,5 +1,0 @@
----
-"training-app": patch
----
-
-Disable Postgres schema auto-push (`push: false`). Schema changes now go exclusively through migrations (`payload migrate:create` + `payload migrate`), so running `yarn dev` can no longer sync schema directly into a remote/production database. After this change a fresh database must be migrated before the app can run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # training-app
 
+## 1.1.1
+
+### Patch Changes
+
+- d7d2235: Disable Postgres schema auto-push (`push: false`). Schema changes now go exclusively through migrations (`payload migrate:create` + `payload migrate`), so running `yarn dev` can no longer sync schema directly into a remote/production database. After this change a fresh database must be migrated before the app can run.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "training-app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Aplikacja treningowa na Payload 3",
   "license": "MIT",
   "type": "module",

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -52,6 +52,9 @@ export default buildConfig({
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
   db: postgresAdapter({
+    // Never auto-sync schema from models. Schema changes go through migrations only
+    // (migrate:create + migrate), so `yarn dev` can never push to a remote/prod DB.
+    push: false,
     pool: {
       connectionString: process.env.DATABASE_URL || '',
       max: 10,


### PR DESCRIPTION
## 1.1.1

### Patch Changes

- d7d2235: Disable Postgres schema auto-push (`push: false`). Schema changes now go exclusively through migrations (`payload migrate:create` + `payload migrate`), so running `yarn dev` can no longer sync schema directly into a remote/production database. After this change a fresh database must be migrated before the app can run.
